### PR TITLE
Shell build file and test fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.exe
 *.csv
+octet

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+CC="cc"
+CFLAGS="-std=c99 -Wall -Wextra -pedantic -I ./include -lm"
+BIN="octet"
+SRC="$(find ./src -type f -name '*.c' -printf '%h/%f ')\
+     $(find ./tests -type f -name '*.c' -printf '%h/%f ')"
+
+if [ "$1" = "TEST" ]; then
+    CFLAGS="${CFLAGS} -ggdb"
+    exec ${CC} ${CFLAGS} ${SRC} -o ${BIN}
+fi

--- a/tests/preparer_tests.c
+++ b/tests/preparer_tests.c
@@ -17,7 +17,13 @@ static MunitResult PrepareDataFromDir_Dataset_ShouldProcessAndLoad(const MunitPa
     char labels[8] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'};
 
     for (int i = 0; i < trainingData->characterCount; i++) {
-        munit_assert_uint8(trainingData->characters[i].label, ==, labels[i]);
+        char c;
+        for (int n = 0; n < sizeof(labels); n++) {
+            c = labels[n];
+            if (c == trainingData->characters[i].label)
+                break;
+        }
+        munit_assert_uint8(trainingData->characters[i].label, ==, c);
     }
 
     return MUNIT_OK;


### PR DESCRIPTION
Added a shell build file with the same behavior as the .bat counterpart, should be compatible with all Unix/Linux.
Fixed a small issue with one of the tests, where it expected readdir(3) to open the directory in a sorted order.